### PR TITLE
Add supportsVolumeSet to StorageVolumeType

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/StorageVolumeType.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/StorageVolumeType.java
@@ -60,6 +60,7 @@ public class StorageVolumeType extends MorpheusModel {
 	// (SAN/networked storage) can be reattached to different servers. Set to true
 	// for native storage so instance reconfigure can ignore those types.
 	protected Boolean nativeVolume = false;
+	protected Boolean supportsVolumeSet = false;
 
 	// associations
 	Collection<OptionType> optionTypes;
@@ -305,5 +306,13 @@ public class StorageVolumeType extends MorpheusModel {
 
 	public void setNativeVolume(Boolean nativeVolume) {
 		this.nativeVolume = nativeVolume;
+	}
+
+	public Boolean getSupportsVolumeSet() {
+		return supportsVolumeSet;
+	}
+
+	public void setSupportsVolumeSet(Boolean supportsVolumeSet) {
+		this.supportsVolumeSet = supportsVolumeSet;
 	}
 }


### PR DESCRIPTION
## Summary
- add supportsVolumeSet boolean field to StorageVolumeType
- add getter and setter for supportsVolumeSet
- default the field to false

## Why
This allows storage volume types to explicitly indicate whether they support volume sets.

## Changes
- morpheus-plugin-api/src/main/java/com/morpheusdata/model/StorageVolumeType.java
  - added protected Boolean supportsVolumeSet = false;
  - added getSupportsVolumeSet()
  - added setSupportsVolumeSet(Boolean supportsVolumeSet)