### PR TITLE
MORPH-10880: Remove SNI-stripping prepareSocket override in HttpApiClient/RestApiUtil 

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/HttpApiClient.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/HttpApiClient.java
@@ -1039,15 +1039,6 @@ public class HttpApiClient {
 				sslConnectionFactory = new SSLConnectionSocketFactory(sslcontext, SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER) {
 
 					@Override
-					protected void prepareSocket(SSLSocket socket) {
-
-						List<SNIServerName> serverNames = Collections.<SNIServerName>emptyList();
-						SSLParameters sslParams = socket.getSSLParameters();
-						sslParams.setServerNames(serverNames);
-						socket.setSSLParameters(sslParams);
-					}
-
-					@Override
 					public Socket connectSocket(int connectTimeout, Socket socket, HttpHost host, InetSocketAddress remoteAddress, InetSocketAddress localAddress, HttpContext context) throws IOException, ConnectTimeoutException {
 						if (socket instanceof SSLSocket) {
 							try {

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/RestApiUtil.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/RestApiUtil.java
@@ -465,13 +465,6 @@ public class RestApiUtil {
 				sslConnectionFactory = new SSLConnectionSocketFactory(sslcontext, SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER) {
 
 					@Override
-					protected void prepareSocket(SSLSocket socket) {
-						List<SNIServerName> serverNames  = Collections.<SNIServerName> emptyList();
-						SSLParameters sslParams = socket.getSSLParameters();
-						sslParams.setServerNames(serverNames);
-						socket.setSSLParameters(sslParams);
-					}
-					@Override
 					public Socket connectSocket(int connectTimeout, Socket socket, HttpHost host, InetSocketAddress remoteAddress, InetSocketAddress localAddress, HttpContext context) throws IOException, ConnectTimeoutException {
 						if(socket instanceof SSLSocket) {
 							try {


### PR DESCRIPTION
## Summary

Fixes [MORPH-10880](https://hpe.atlassian.net/browse/MORPH-10880).

`HttpApiClient.java` and `RestApiUtil.java` both build their `ignoreSSL=true` (default) TLS socket factory with a `prepareSocket()` override that explicitly clears the `SNIServerName` list before every handshake. This strips SNI from the `ClientHello` on every request that uses default `RequestOptions` — which includes all Kubernetes API calls in `KubernetesComputeUtility.groovy`, none of which explicitly set `ignoreSSL`. Endpoints behind SNI-routing load balancers (e.g. OVH Managed Kubernetes) have nowhere to route an SNI-less handshake and terminate the connection with `SSLHandshakeException: Remote host terminated the handshake`.

The trust-all / hostname-verification-disabled behavior of `ignoreSSL=true` is handled independently via `TrustStrategy` and `ALLOW_ALL_HOSTNAME_VERIFIER` — neither depends on the `prepareSocket()` override, so removing it only restores normal SNI behavior without weakening the (intentional) trust-all semantics.

## Fix

Removed the SNI-stripping `prepareSocket()` override in both `HttpApiClient.java` and `RestApiUtil.java`.

## Testing

Live end-to-end reproduction (not just a mock): stood up a local TLS server that mimics an SNI-routing load balancer (aborts the handshake if no SNI is presented), and ran the real `HttpApiClient.callApi(...)` against it using a real hostname (`127.0.0.1.nip.io`, resolves via public DNS to `127.0.0.1`) so the JVM would send a genuine SNI extension.

| Code version | SNI sent by client | Handshake result |
|---|---|---|
| Pre-fix | `SNI=None` | Failed - `success=false` |
| Post-fix | `SNI='127.0.0.1.nip.io'` | Succeeded - `success=true` |

Also verified `./gradlew :morpheus-plugin-api:compileJava` compiles clean.