### PR TITLE
MORPH-16093: Add StorageVolumeGroup model and service interfaces

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusStorageService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusStorageService.java
@@ -75,6 +75,15 @@ public interface MorpheusStorageService {
 	MorpheusStorageAggregateService getAggregate();
 
 	/**
+	 * Returns the StorageVolumeGroup Service for managing volume groups
+	 * used in consistent snapshot and replication operations.
+	 *
+	 * @return An instance of the StorageVolumeGroup Service
+	 * @since 1.4.0
+	 */
+	MorpheusStorageVolumeGroupService getVolumeGroup();
+
+	/**
 	 * Validates an update on a {@link StorageServer} before executing the update.
 	 * @deprecated use {@link MorpheusStorageServerService#validateUpdate(UpdateDefinition, StorageServer)}  instead
 	 */

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusStorageVolumeGroupService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusStorageVolumeGroupService.java
@@ -1,0 +1,242 @@
+/*
+ *  Copyright 2026 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.core;
+
+import com.morpheusdata.model.StorageServer;
+import com.morpheusdata.model.StorageVolume;
+import com.morpheusdata.model.StorageVolumeGroup;
+import com.morpheusdata.model.projection.StorageVolumeGroupIdentityProjection;
+import com.morpheusdata.response.ServiceResponse;
+import io.reactivex.rxjava3.core.Observable;
+import io.reactivex.rxjava3.core.Single;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Context methods for managing {@link StorageVolumeGroup} entities in Morpheus.
+ * <p>
+ * StorageVolumeGroup represents a logical grouping of storage volumes that can be managed
+ * together for consistent snapshot and replication operations. This service provides:
+ * <ul>
+ *   <li>CRUD operations for volume groups</li>
+ *   <li>Volume membership management (add/remove volumes)</li>
+ *   <li>Sync operations for plugin-based data synchronization</li>
+ *   <li>Provider delegation for storage-level operations</li>
+ * </ul>
+ * <p>
+ * When volumes are added or removed from a group, the operation is delegated to the
+ * appropriate {@link com.morpheusdata.core.providers.StorageProviderVolumeGroupsFacet} implementation
+ * so plugins can take action at the storage array level.
+ *
+ * @author Amol Lele
+ * @since 1.4.0
+ * @see StorageVolumeGroup
+ * @see com.morpheusdata.core.providers.StorageProviderVolumeGroupsFacet
+ */
+public interface MorpheusStorageVolumeGroupService extends MorpheusDataService<StorageVolumeGroup, StorageVolumeGroupIdentityProjection>, MorpheusIdentityService<StorageVolumeGroupIdentityProjection> {
+
+	// ============================================================================
+	// Query Operations
+	// ============================================================================
+
+	/**
+	 * Get a list of StorageVolumeGroup projections based on StorageServer id.
+	 * @param storageServerId the storage server to filter by
+	 * @return Observable stream of identity projections
+	 */
+	Observable<StorageVolumeGroupIdentityProjection> listIdentityProjections(Long storageServerId);
+
+	/**
+	 * Get a list of StorageVolumeGroup projections based on StorageServer.
+	 * @param storageServer the storage server to filter by
+	 * @return Observable stream of identity projections
+	 */
+	Observable<StorageVolumeGroupIdentityProjection> listIdentityProjections(StorageServer storageServer);
+
+	/**
+	 * List all volume groups for a storage server.
+	 * @param storageServer the storage server
+	 * @return Observable stream of volume groups
+	 */
+	Observable<StorageVolumeGroup> listByStorageServer(StorageServer storageServer);
+
+	/**
+	 * List all volume groups for a storage server by ID.
+	 * @param storageServerId the storage server ID
+	 * @return Observable stream of volume groups
+	 */
+	Observable<StorageVolumeGroup> listByStorageServerId(Long storageServerId);
+
+	/**
+	 * Find a volume group by external ID within a storage server.
+	 * @param storageServerId the storage server ID
+	 * @param externalId the external ID from the storage system
+	 * @return Single containing the volume group if found
+	 */
+	Single<StorageVolumeGroup> findByExternalId(Long storageServerId, String externalId);
+
+	/**
+	 * Find a volume group by name within a storage server.
+	 * @param storageServerId the storage server ID
+	 * @param name the volume group name
+	 * @return Single containing the volume group if found
+	 */
+	Single<StorageVolumeGroup> findByName(Long storageServerId, String name);
+
+	// ============================================================================
+	// Volume Membership Operations (with Provider Delegation)
+	// ============================================================================
+
+	/**
+	 * Add volumes to a volume group.
+	 * <p>
+	 * This operation validates that:
+	 * <ul>
+	 *   <li>The volumes are not already in another group</li>
+	 *   <li>The volumes belong to the same storage server as the group</li>
+	 * </ul>
+	 * The operation is delegated to the storage provider plugin via
+	 * {@link com.morpheusdata.core.providers.StorageProviderVolumeGroupsFacet#addVolumesToVolumeGroup}
+	 * so the plugin can update the storage array.
+	 *
+	 * @param volumeGroup the volume group to add volumes to
+	 * @param volumes the volumes to add
+	 * @param opts additional options for the operation
+	 * @return ServiceResponse indicating success/failure with updated volume group
+	 */
+	Single<ServiceResponse<StorageVolumeGroup>> addVolumes(StorageVolumeGroup volumeGroup, List<StorageVolume> volumes, Map<String, Object> opts);
+
+	/**
+	 * Add a single volume to a volume group.
+	 * @param volumeGroup the volume group
+	 * @param volume the volume to add
+	 * @return ServiceResponse indicating success/failure
+	 */
+	default Single<ServiceResponse<StorageVolumeGroup>> addVolume(StorageVolumeGroup volumeGroup, StorageVolume volume) {
+		return addVolumes(volumeGroup, List.of(volume), Map.of());
+	}
+
+	/**
+	 * Remove volumes from a volume group.
+	 * <p>
+	 * The operation is delegated to the storage provider plugin via
+	 * {@link com.morpheusdata.core.providers.StorageProviderVolumeGroupsFacet#removeVolumesFromVolumeGroup}
+	 * so the plugin can update the storage array.
+	 *
+	 * @param volumeGroup the volume group to remove volumes from
+	 * @param volumes the volumes to remove
+	 * @param opts additional options for the operation
+	 * @return ServiceResponse indicating success/failure with updated volume group
+	 */
+	Single<ServiceResponse<StorageVolumeGroup>> removeVolumes(StorageVolumeGroup volumeGroup, List<StorageVolume> volumes, Map<String, Object> opts);
+
+	/**
+	 * Remove a single volume from a volume group.
+	 * @param volumeGroup the volume group
+	 * @param volume the volume to remove
+	 * @return ServiceResponse indicating success/failure
+	 */
+	default Single<ServiceResponse<StorageVolumeGroup>> removeVolume(StorageVolumeGroup volumeGroup, StorageVolume volume) {
+		return removeVolumes(volumeGroup, List.of(volume), Map.of());
+	}
+
+	// ============================================================================
+	// CRUD Operations (with Provider Delegation)
+	// ============================================================================
+
+	/**
+	 * Create a new volume group on the storage server.
+	 * <p>
+	 * This operation delegates to the storage provider plugin via
+	 * {@link com.morpheusdata.core.providers.StorageProviderVolumeGroupsFacet#createVolumeGroup}
+	 * to create the group on the actual storage array.
+	 *
+	 * @param storageServer the storage server to create the group on
+	 * @param volumeGroup the volume group to create
+	 * @param opts additional options
+	 * @return ServiceResponse with the created volume group
+	 */
+	Single<ServiceResponse<StorageVolumeGroup>> createVolumeGroup(StorageServer storageServer, StorageVolumeGroup volumeGroup, Map<String, Object> opts);
+
+	/**
+	 * Update an existing volume group.
+	 * <p>
+	 * Uses optimistic locking via the version field. If the version has changed
+	 * since the group was loaded, the update will fail with a conflict error.
+	 *
+	 * @param volumeGroup the volume group to update
+	 * @param opts additional options
+	 * @return ServiceResponse with the updated volume group
+	 */
+	Single<ServiceResponse<StorageVolumeGroup>> updateVolumeGroup(StorageVolumeGroup volumeGroup, Map<String, Object> opts);
+
+	/**
+	 * Delete a volume group.
+	 * <p>
+	 * This operation will fail if:
+	 * <ul>
+	 *   <li>The group has active replication relationships (FR-066)</li>
+	 *   <li>The group still contains volumes (depending on force flag)</li>
+	 * </ul>
+	 *
+	 * @param volumeGroup the volume group to delete
+	 * @param opts additional options (e.g., "force" to remove volumes first)
+	 * @return ServiceResponse indicating success/failure
+	 */
+	Single<ServiceResponse> deleteVolumeGroup(StorageVolumeGroup volumeGroup, Map<String, Object> opts);
+
+	/**
+	 * Check if a volume group can be deleted.
+	 * <p>
+	 * Validates that:
+	 * <ul>
+	 *   <li>No active replication relationships exist</li>
+	 *   <li>Group is not in a protected state</li>
+	 * </ul>
+	 *
+	 * @param volumeGroup the volume group to check
+	 * @return ServiceResponse with canDelete=true/false and reason if not deletable
+	 */
+	Single<ServiceResponse<Boolean>> canDelete(StorageVolumeGroup volumeGroup);
+
+	// ============================================================================
+	// Sync Operations (for Plugin Data Synchronization)
+	// ============================================================================
+
+	/**
+	 * Create volume groups in bulk during sync operations.
+	 * @param volumeGroups the volume groups to create
+	 * @return success indicator
+	 */
+	Single<Boolean> create(List<StorageVolumeGroup> volumeGroups);
+
+	/**
+	 * Save (update) volume groups in bulk during sync operations.
+	 * @param volumeGroups the volume groups to save
+	 * @return success indicator
+	 */
+	Single<Boolean> save(List<StorageVolumeGroup> volumeGroups);
+
+	/**
+	 * Remove volume groups in bulk during sync operations.
+	 * @param volumeGroups the volume groups to remove
+	 * @return success indicator
+	 */
+	Single<Boolean> remove(List<StorageVolumeGroupIdentityProjection> volumeGroups);
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusSynchronousStorageService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusSynchronousStorageService.java
@@ -35,6 +35,14 @@ public interface MorpheusSynchronousStorageService {
 	MorpheusSynchronousStorageVolumeService getVolume();
 
 	/**
+	 * Returns the StorageVolumeGroup Service
+	 *
+	 * @return An instance of the StorageVolumeGroup Service
+	 * @since 1.5.0
+	 */
+	MorpheusSynchronousStorageVolumeGroupService getVolumeGroup();
+
+	/**
 	 * Returns the StorageController Service
 	 *
 	 * @return An instance of the StorageController Service

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/StorageProviderVolumeGroupsFacet.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/StorageProviderVolumeGroupsFacet.java
@@ -1,0 +1,246 @@
+/*
+ *  Copyright 2026 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.core.providers;
+
+import com.morpheusdata.model.StorageServer;
+import com.morpheusdata.model.StorageVolume;
+import com.morpheusdata.model.StorageVolumeGroup;
+import com.morpheusdata.response.ServiceResponse;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Facet interface for storage providers that support volume grouping for consistent
+ * snapshot and replication operations.
+ * <p>
+ * This facet is used in combination with {@link StorageProvider} to define a
+ * {@link com.morpheusdata.model.StorageServerType} that supports grouping volumes
+ * for crash-consistent or application-consistent snapshots.
+ * <p>
+ * When Morpheus orchestration needs to create, modify, or delete volume groups,
+ * or add/remove volumes from groups, it delegates to the appropriate methods
+ * on this facet. Plugin implementations should translate these operations
+ * to the underlying storage array API.
+ * <p>
+ * Example implementation for HPE Alletra:
+ * <pre>{@code
+ * public class AlletraStorageProvider implements StorageProvider, StorageProviderVolumeGroupsFacet {
+ *     @Override
+ *     public ServiceResponse<StorageVolumeGroup> createVolumeGroup(
+ *             StorageServer storageServer, StorageVolumeGroup volumeGroup, Map opts) {
+ *         // Call HPE Alletra REST API to create volume set
+ *         def client = getClient(storageServer)
+ *         def result = client.createVolumeSet(volumeGroup.getName(), ...)
+ *         volumeGroup.setExternalId(result.id)
+ *         return ServiceResponse.success(volumeGroup)
+ *     }
+ * }
+ * }</pre>
+ *
+ * @author Amol Lele
+ * @since 1.5.0
+ * @see StorageProvider
+ * @see StorageVolumeGroup
+ */
+public interface StorageProviderVolumeGroupsFacet {
+
+	// ============================================================================
+	// Volume Group CRUD Operations
+	// ============================================================================
+
+	/**
+	 * Create a new volume group on the storage array.
+	 * <p>
+	 * The plugin should:
+	 * <ol>
+	 *   <li>Validate the volume group name (max 22 chars for Remote Copy)</li>
+	 *   <li>Create the volume group/set on the storage array</li>
+	 *   <li>Set the externalId on the volumeGroup from the array response</li>
+	 *   <li>Optionally add initial volumes if volumeGroup.volumes is populated</li>
+	 * </ol>
+	 *
+	 * @param storageServer the storage server to create the group on
+	 * @param volumeGroup the volume group to create (name, description, etc.)
+	 * @param opts additional options (e.g., application-consistent settings)
+	 * @return ServiceResponse with the created volume group (externalId populated)
+	 */
+	ServiceResponse<StorageVolumeGroup> createVolumeGroup(StorageServer storageServer, StorageVolumeGroup volumeGroup, Map<String, Object> opts);
+
+	/**
+	 * Update an existing volume group on the storage array.
+	 * <p>
+	 * The plugin should update properties like description, applicationConsistent flag, etc.
+	 * Note: Volume membership changes should use addVolumesToVolumeGroup/removeVolumesFromVolumeGroup.
+	 *
+	 * @param storageServer the storage server
+	 * @param volumeGroup the volume group with updated properties
+	 * @param opts additional options
+	 * @return ServiceResponse with the updated volume group
+	 */
+	default ServiceResponse<StorageVolumeGroup> updateVolumeGroup(StorageServer storageServer, StorageVolumeGroup volumeGroup, Map<String, Object> opts) {
+		return ServiceResponse.success(volumeGroup);
+	}
+
+	/**
+	 * Delete a volume group from the storage array.
+	 * <p>
+	 * The plugin should:
+	 * <ol>
+	 *   <li>Verify no active replication relationships exist</li>
+	 *   <li>Optionally remove volumes from the group first (based on opts)</li>
+	 *   <li>Delete the volume group/set from the array</li>
+	 * </ol>
+	 *
+	 * @param storageServer the storage server
+	 * @param volumeGroup the volume group to delete
+	 * @param opts additional options (e.g., "force" to delete even with volumes)
+	 * @return ServiceResponse indicating success/failure
+	 */
+	ServiceResponse deleteVolumeGroup(StorageServer storageServer, StorageVolumeGroup volumeGroup, Map<String, Object> opts);
+
+	// ============================================================================
+	// Volume Membership Operations
+	// ============================================================================
+
+	/**
+	 * Add volumes to an existing volume group on the storage array.
+	 * <p>
+	 * The plugin should:
+	 * <ol>
+	 *   <li>Validate all volumes exist and are not in another group</li>
+	 *   <li>Add the volumes to the volume set/group on the array</li>
+	 *   <li>Return updated volume count and storage metrics</li>
+	 * </ol>
+	 *
+	 * @param storageServer the storage server
+	 * @param volumeGroup the volume group to add volumes to
+	 * @param volumes the volumes to add
+	 * @param opts additional options
+	 * @return ServiceResponse with the updated volume group
+	 */
+	ServiceResponse<StorageVolumeGroup> addVolumesToVolumeGroup(StorageServer storageServer, StorageVolumeGroup volumeGroup, List<StorageVolume> volumes, Map<String, Object> opts);
+
+	/**
+	 * Remove volumes from a volume group on the storage array.
+	 * <p>
+	 * The plugin should:
+	 * <ol>
+	 *   <li>Validate all volumes are currently in this group</li>
+	 *   <li>Remove the volumes from the volume set/group on the array</li>
+	 *   <li>Return updated volume count and storage metrics</li>
+	 * </ol>
+	 *
+	 * @param storageServer the storage server
+	 * @param volumeGroup the volume group to remove volumes from
+	 * @param volumes the volumes to remove
+	 * @param opts additional options
+	 * @return ServiceResponse with the updated volume group
+	 */
+	ServiceResponse<StorageVolumeGroup> removeVolumesFromVolumeGroup(StorageServer storageServer, StorageVolumeGroup volumeGroup, List<StorageVolume> volumes, Map<String, Object> opts);
+
+	// ============================================================================
+	// Validation and Query Operations
+	// ============================================================================
+
+	/**
+	 * Check if a volume group can be deleted.
+	 * <p>
+	 * The plugin should check:
+	 * <ul>
+	 *   <li>No active replication relationships</li>
+	 *   <li>No pending snapshot operations</li>
+	 *   <li>Group is not in a protected state</li>
+	 * </ul>
+	 *
+	 * @param storageServer the storage server
+	 * @param volumeGroup the volume group to check
+	 * @return ServiceResponse with canDelete=true/false and reason message
+	 */
+	default ServiceResponse<Boolean> canDeleteVolumeGroup(StorageServer storageServer, StorageVolumeGroup volumeGroup) {
+		return ServiceResponse.success(true);
+	}
+
+	/**
+	 * Validate a volume group name according to vendor-specific requirements.
+	 * <p>
+	 * Default implementation only checks that the name is not null or empty.
+	 * Storage providers should override this method to enforce vendor-specific
+	 * name constraints (e.g., HPE Remote Copy requires max 22 characters).
+	 * <p>
+	 * Example override for HPE Alletra:
+	 * <pre>{@code
+	 * @Override
+	 * public ServiceResponse<Boolean> validateVolumeGroupName(String name) {
+	 *     if (name == null || name.trim().isEmpty()) {
+	 *         return ServiceResponse.error("Volume group name cannot be empty");
+	 *     }
+	 *     if (name.length() > 22) {
+	 *         return ServiceResponse.error("Volume group name exceeds 22 character limit for Remote Copy");
+	 *     }
+	 *     return ServiceResponse.success(true);
+	 * }
+	 * }</pre>
+	 *
+	 * @param name the proposed volume group name
+	 * @return ServiceResponse with valid=true/false and error message
+	 */
+	default ServiceResponse<Boolean> validateVolumeGroupName(String name) {
+		if (name == null || name.trim().isEmpty()) {
+			return ServiceResponse.error("Volume group name cannot be empty");
+		}
+		return ServiceResponse.success(true);
+	}
+
+	/**
+	 * Check if a volume can be added to a volume group.
+	 * <p>
+	 * The plugin should verify:
+	 * <ul>
+	 *   <li>Volume is not already in another group</li>
+	 *   <li>Volume is on the same storage server</li>
+	 *   <li>Volume type is compatible with the group</li>
+	 * </ul>
+	 *
+	 * @param storageServer the storage server
+	 * @param volumeGroup the target volume group
+	 * @param volume the volume to check
+	 * @return ServiceResponse with canAdd=true/false and reason
+	 */
+	default ServiceResponse<Boolean> canAddVolumeToGroup(StorageServer storageServer, StorageVolumeGroup volumeGroup, StorageVolume volume) {
+		return ServiceResponse.success(true);
+	}
+
+	/**
+	 * Refresh volume group data from the storage array.
+	 * <p>
+	 * The plugin should query the array for current state and update:
+	 * <ul>
+	 *   <li>Volume membership</li>
+	 *   <li>Storage metrics (maxStorage, usedStorage)</li>
+	 *   <li>Status and any error conditions</li>
+	 * </ul>
+	 *
+	 * @param storageServer the storage server
+	 * @param volumeGroup the volume group to refresh
+	 * @return ServiceResponse with refreshed volume group data
+	 */
+	default ServiceResponse<StorageVolumeGroup> refreshVolumeGroup(StorageServer storageServer, StorageVolumeGroup volumeGroup) {
+		return ServiceResponse.success(volumeGroup);
+	}
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/MorpheusSynchronousStorageVolumeGroupService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/MorpheusSynchronousStorageVolumeGroupService.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright 2026 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.core.synchronous;
+
+import com.morpheusdata.core.MorpheusSynchronousDataService;
+import com.morpheusdata.core.MorpheusSynchronousIdentityService;
+import com.morpheusdata.model.StorageVolumeGroup;
+import com.morpheusdata.model.projection.StorageVolumeGroupIdentityProjection;
+
+/**
+ * Blocking counterpart to {@link com.morpheusdata.core.MorpheusStorageVolumeGroupService} for use in
+ * synchronous plugin code (e.g. blocking-style sync tasks). Provides {@code bulkCreate}/{@code bulkSave}/
+ * {@code bulkRemove} and other standard CRUD/query methods via {@link MorpheusSynchronousDataService}.
+ *
+ * @author Amol Lele
+ * @since 1.5.0
+ * @see com.morpheusdata.core.MorpheusStorageVolumeGroupService
+ */
+public interface MorpheusSynchronousStorageVolumeGroupService extends MorpheusSynchronousDataService<StorageVolumeGroup, StorageVolumeGroupIdentityProjection>, MorpheusSynchronousIdentityService<StorageVolumeGroupIdentityProjection> {
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/StorageVolume.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/StorageVolume.java
@@ -66,6 +66,14 @@ public class StorageVolume extends StorageVolumeIdentityProjection {
 	@JsonSerialize(using= ModelAsIdOnlySerializer.class)
 	protected StorageGroup storageGroup;
 
+	/**
+	 * The volume group this volume belongs to for consistent snapshot operations.
+	 * A volume can belong to at most one volume group.
+	 * @since 1.4.0
+	 */
+	@JsonSerialize(using= ModelAsIdOnlySerializer.class)
+	protected StorageVolumeGroup volumeGroup;
+
 	protected String volumeType = "disk";
 	protected String volumePath;
 	protected String diskType;
@@ -421,6 +429,26 @@ public class StorageVolume extends StorageVolumeIdentityProjection {
 	public void setStorageGroup(StorageGroup storageGroup) {
 		this.storageGroup = storageGroup;
 		markDirty("storageGroup", storageGroup);
+	}
+
+	/**
+	 * Gets the volume group this volume belongs to for consistent snapshots.
+	 * @return the volume group, or null if not in a group
+	 * @since 1.4.0
+	 */
+	public StorageVolumeGroup getVolumeGroup() {
+		return volumeGroup;
+	}
+
+	/**
+	 * Sets the volume group this volume belongs to.
+	 * A volume can belong to at most one volume group.
+	 * @param volumeGroup the volume group
+	 * @since 1.4.0
+	 */
+	public void setVolumeGroup(StorageVolumeGroup volumeGroup) {
+		this.volumeGroup = volumeGroup;
+		markDirty("volumeGroup", volumeGroup);
 	}
 
 	public String getPoolName() {

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/StorageVolumeGroup.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/StorageVolumeGroup.java
@@ -1,0 +1,272 @@
+/*
+ *  Copyright 2026 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.morpheusdata.model.projection.StorageVolumeGroupIdentityProjection;
+import com.morpheusdata.model.serializers.ModelAsIdOnlySerializer;
+import com.morpheusdata.model.serializers.ModelCollectionAsIdsOnlySerializer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Represents a logical grouping of storage volumes for consistent snapshot and replication operations.
+ * <p>
+ * A StorageVolumeGroup enables volumes to be snapshotted together in a crash-consistent or
+ * application-consistent manner. This is essential for database and multi-volume application
+ * workloads where point-in-time consistency across volumes is required.
+ * <p>
+ * Key constraints:
+ * <ul>
+ *   <li>A volume can belong to at most one volume group</li>
+ *   <li>Supports optimistic locking via version field (FR-009a)</li>
+ *   <li>Cannot be deleted if active replication relationships exist (FR-066)</li>
+ *   <li>Name length validation is vendor-specific and enforced by the storage provider plugin</li>
+ * </ul>
+ *
+ * @author Amol Lele
+ * @since 1.5.0
+ * @see StorageVolume
+ * @see StorageServer
+ */
+public class StorageVolumeGroup extends StorageVolumeGroupIdentityProjection {
+
+	@JsonSerialize(using = ModelAsIdOnlySerializer.class)
+	protected Account account;
+
+	@JsonSerialize(using = ModelAsIdOnlySerializer.class)
+	protected StorageServer storageServer;
+
+	protected String code;
+	protected String description;
+	protected String status;
+	protected String statusMessage;
+	protected Date statusDate;
+
+	/**
+	 * Version for optimistic locking. Incremented on each update to detect concurrent modifications.
+	 */
+	protected Long version;
+
+	/**
+	 * Indicates whether snapshots of this group are application-consistent (true) or crash-consistent (false).
+	 */
+	protected Boolean applicationConsistent = false;
+
+	/**
+	 * Maximum aggregate storage capacity across all volumes in bytes.
+	 */
+	protected Long maxStorage;
+
+	/**
+	 * Current used storage across all volumes in bytes.
+	 */
+	protected Long usedStorage;
+
+	/**
+	 * Number of volumes currently in this group.
+	 */
+	protected Integer volumeCount = 0;
+
+	@JsonSerialize(using = ModelCollectionAsIdsOnlySerializer.class)
+	protected List<StorageVolume> volumes = new ArrayList<>();
+
+	protected String rawData;
+	protected Boolean enabled = true;
+	protected Date dateCreated;
+	protected Date lastUpdated;
+
+	// Constructors
+
+	public StorageVolumeGroup() {
+		// default constructor
+	}
+
+	// Getters and Setters
+
+	public Account getAccount() {
+		return account;
+	}
+
+	public void setAccount(Account account) {
+		this.account = account;
+		markDirty("account", account);
+	}
+
+	public StorageServer getStorageServer() {
+		return storageServer;
+	}
+
+	public void setStorageServer(StorageServer storageServer) {
+		this.storageServer = storageServer;
+		markDirty("storageServer", storageServer);
+	}
+
+	public String getCode() {
+		return code;
+	}
+
+	public void setCode(String code) {
+		this.code = code;
+		markDirty("code", code);
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+		markDirty("description", description);
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+		markDirty("status", status);
+	}
+
+	public String getStatusMessage() {
+		return statusMessage;
+	}
+
+	public void setStatusMessage(String statusMessage) {
+		this.statusMessage = statusMessage;
+		markDirty("statusMessage", statusMessage);
+	}
+
+	public Date getStatusDate() {
+		return statusDate;
+	}
+
+	public void setStatusDate(Date statusDate) {
+		this.statusDate = statusDate;
+		markDirty("statusDate", statusDate);
+	}
+
+	/**
+	 * Gets the version number for optimistic locking.
+	 * @return the current version
+	 */
+	public Long getVersion() {
+		return version;
+	}
+
+	/**
+	 * Sets the version number. Typically managed by the persistence layer.
+	 * @param version the version number
+	 */
+	public void setVersion(Long version) {
+		this.version = version;
+		markDirty("version", version);
+	}
+
+	/**
+	 * Gets whether snapshots are application-consistent.
+	 * @return true for application-consistent, false for crash-consistent
+	 */
+	public Boolean getApplicationConsistent() {
+		return applicationConsistent;
+	}
+
+	/**
+	 * Sets whether snapshots should be application-consistent.
+	 * @param applicationConsistent true for application-consistent snapshots
+	 */
+	public void setApplicationConsistent(Boolean applicationConsistent) {
+		this.applicationConsistent = applicationConsistent;
+		markDirty("applicationConsistent", applicationConsistent);
+	}
+
+	public Long getMaxStorage() {
+		return maxStorage;
+	}
+
+	public void setMaxStorage(Long maxStorage) {
+		this.maxStorage = maxStorage;
+		markDirty("maxStorage", maxStorage);
+	}
+
+	public Long getUsedStorage() {
+		return usedStorage;
+	}
+
+	public void setUsedStorage(Long usedStorage) {
+		this.usedStorage = usedStorage;
+		markDirty("usedStorage", usedStorage);
+	}
+
+	public Integer getVolumeCount() {
+		return volumeCount;
+	}
+
+	public void setVolumeCount(Integer volumeCount) {
+		this.volumeCount = volumeCount;
+		markDirty("volumeCount", volumeCount);
+	}
+
+	public List<StorageVolume> getVolumes() {
+		return volumes;
+	}
+
+	public void setVolumes(List<StorageVolume> volumes) {
+		this.volumes = volumes;
+		markDirty("volumes", volumes);
+	}
+
+	public String getRawData() {
+		return rawData;
+	}
+
+	public void setRawData(String rawData) {
+		this.rawData = rawData;
+		markDirty("rawData", rawData);
+	}
+
+	public Boolean getEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(Boolean enabled) {
+		this.enabled = enabled;
+		markDirty("enabled", enabled);
+	}
+
+	public Date getDateCreated() {
+		return dateCreated;
+	}
+
+	public void setDateCreated(Date dateCreated) {
+		this.dateCreated = dateCreated;
+		markDirty("dateCreated", dateCreated);
+	}
+
+	public Date getLastUpdated() {
+		return lastUpdated;
+	}
+
+	public void setLastUpdated(Date lastUpdated) {
+		this.lastUpdated = lastUpdated;
+		markDirty("lastUpdated", lastUpdated);
+	}
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/projection/StorageVolumeGroupIdentityProjection.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/projection/StorageVolumeGroupIdentityProjection.java
@@ -43,8 +43,7 @@ public class StorageVolumeGroupIdentityProjection extends MorpheusIdentityModel 
 	}
 
 	/**
-	 * Gets the name of the volume group. Name is limited to 22 characters for
-	 * Remote Copy compatibility with HPE storage systems.
+	 * Gets the name of the volume group.
 	 * @return the current name of the volume group
 	 */
 	public String getName() {
@@ -52,8 +51,9 @@ public class StorageVolumeGroupIdentityProjection extends MorpheusIdentityModel 
 	}
 
 	/**
-	 * Sets the name of the volume group.
-	 * @param name the name of the volume group (max 22 characters)
+	 * Sets the name of the volume group. Name length/format constraints are
+	 * vendor-specific and enforced by the storage provider plugin.
+	 * @param name the name of the volume group
 	 */
 	public void setName(String name) {
 		this.name = name;

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/projection/StorageVolumeGroupIdentityProjection.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/projection/StorageVolumeGroupIdentityProjection.java
@@ -1,0 +1,96 @@
+/*
+ *  Copyright 2026 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.model.projection;
+
+/**
+ * Provides a subset of properties from the StorageVolumeGroup object for doing a sync match
+ * comparison with less bandwidth usage and memory footprint. This is a DTO Projection object.
+ * <p>
+ * StorageVolumeGroup represents a logical grouping of storage volumes that can be managed
+ * together for consistent snapshot and replication operations.
+ *
+ * @author Amol Lele
+ * @since 1.4.0
+ */
+public class StorageVolumeGroupIdentityProjection extends MorpheusIdentityModel {
+
+	protected String name;
+	protected String externalId;
+	protected String uuid;
+
+	public StorageVolumeGroupIdentityProjection() {
+		// default constructor
+	}
+
+	public StorageVolumeGroupIdentityProjection(Long id, String name, String externalId) {
+		this.id = id;
+		this.name = name;
+		this.externalId = externalId;
+	}
+
+	/**
+	 * Gets the name of the volume group. Name is limited to 22 characters for
+	 * Remote Copy compatibility with HPE storage systems.
+	 * @return the current name of the volume group
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Sets the name of the volume group.
+	 * @param name the name of the volume group (max 22 characters)
+	 */
+	public void setName(String name) {
+		this.name = name;
+		markDirty("name", name);
+	}
+
+	/**
+	 * Returns the externalId (API id) of the volume group from the storage system.
+	 * @return the external id or API id of the current record
+	 */
+	public String getExternalId() {
+		return externalId;
+	}
+
+	/**
+	 * Sets the externalId of the volume group.
+	 * @param externalId the external id from the storage system
+	 */
+	public void setExternalId(String externalId) {
+		this.externalId = externalId;
+		markDirty("externalId", externalId);
+	}
+
+	/**
+	 * Returns the UUID of the volume group.
+	 * @return the uuid of the current record
+	 */
+	public String getUuid() {
+		return uuid;
+	}
+
+	/**
+	 * Sets the UUID of the volume group.
+	 * @param uuid the uuid of the current record
+	 */
+	public void setUuid(String uuid) {
+		this.uuid = uuid;
+		markDirty("uuid", uuid);
+	}
+}


### PR DESCRIPTION
## Summary
Adds plugin-core API support for storage volume groups, enabling volumes to be grouped for consistent (crash-consistent or application-consistent) snapshot operations. Storage array-level operations delegate to a new provider facet so plugins can implement vendor-specific behavior.

## Changes
- `StorageVolumeGroupIdentityProjection`: lightweight sync projection
- `StorageVolumeGroup`: API model for volume groups
- `MorpheusStorageVolumeGroupService`: service interface with CRUD, query, and volume membership operations (add/remove volumes to/from a group)
- `StorageProviderVolumeGroupsFacet`: provider facet plugins implement to delegate volume group operations to the storage array (create/update/delete group, add/remove volumes, name validation, deletion guard)
- `MorpheusStorageService`: added `getVolumeGroup()` accessor
- `StorageVolume`: added `volumeGroup` FK field

## Design notes
- Volume group name length/format constraints are vendor-specific (e.g. HPE Remote Copy limits to 22 characters) and are validated via `StorageProviderVolumeGroupsFacet.validateVolumeGroupName()` rather than hard-coded in the core model.
- A volume can belong to at most one volume group.

## Related
Jira: MORPH-16093
Companion PR: HPE-EMU/morpheus-ui#5642

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>