### PR TITLE
MORPH-15309: Add updateBackup to BackupTypeProvider/BackupExecutionProvider

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/backup/AbstractBackupTypeProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/backup/AbstractBackupTypeProvider.java
@@ -111,6 +111,11 @@ public abstract class AbstractBackupTypeProvider implements BackupTypeProvider {
 	}
 
 	@Override
+	public ServiceResponse updateBackup(Backup backupModel, Map opts) {
+		return getExecutionProvider().updateBackup(backupModel, opts);
+	}
+
+	@Override
 	public ServiceResponse deleteBackup(Backup backupModel, Map opts) {
 		return getExecutionProvider().deleteBackup(backupModel, opts);
 	}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/backup/AbstractMorpheusBackupTypeProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/backup/AbstractMorpheusBackupTypeProvider.java
@@ -60,6 +60,11 @@ public abstract class AbstractMorpheusBackupTypeProvider implements BackupTypePr
 	}
 
 	@Override
+	public ServiceResponse updateBackup(Backup backup, Map opts) {
+		return ServiceResponse.success(backup);
+	}
+
+	@Override
 	public ServiceResponse deleteBackup(Backup backup, Map opts) {
 		return ServiceResponse.success(backup);
 	}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/backup/BackupExecutionProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/backup/BackupExecutionProvider.java
@@ -73,6 +73,23 @@ public interface BackupExecutionProvider {
 	ServiceResponse createBackup(Backup backupModel, Map opts);
 
 	/**
+	 * Add additional configurations to a backup being edited. Morpheus will handle all basic configuration details,
+	 * this is a convenient way to validate/apply additional configuration details specific to this backup provider
+	 * when an existing backup is edited and saved. This mirrors {@link #createBackup(Backup, Map)} for the create flow.
+	 * <p>
+	 * The default implementation is a no-op success, preserving prior behavior for providers implemented before
+	 * this method was introduced (it was never invoked previously). Override this method to add provider-specific
+	 * validation/behavior on edit-save.
+	 * @param backupModel the backup being updated.
+	 * @param opts additional options used during backup update
+	 * @return a {@link ServiceResponse} object. A ServiceResponse with a success value of 'false' will indicate the
+	 * update failed and will halt the backup update process.
+	 */
+	default ServiceResponse updateBackup(Backup backupModel, Map opts) {
+		return ServiceResponse.success(backupModel);
+	}
+
+	/**
 	 * Delete the backup resources on the external provider system.
 	 * @param backupModel the backup details
 	 * @param opts additional options used during the backup deletion process

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/backup/BackupTypeProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/backup/BackupTypeProvider.java
@@ -190,6 +190,18 @@ public interface BackupTypeProvider extends PluginProvider {
 	ServiceResponse createBackup(Backup backup, Map opts);
 
 	/**
+	 * Add additional configurations to a backup being edited. Morpheus will handle all basic configuration details,
+	 * this is a convenient way to validate/apply additional configuration details specific to this backup provider
+	 * when an existing backup is edited and saved. This mirrors {@link #configureBackup(Backup, Map, Map)} for the
+	 * create flow.
+	 * @param backup the backup being updated.
+	 * @param opts optional parameters used for configuration.
+	 * @return a {@link ServiceResponse} object. A ServiceResponse with a false success will indicate a failed
+	 * configuration and will halt the backup update process.
+	 */
+	ServiceResponse updateBackup(Backup backup, Map opts);
+
+	/**
 	 * Delete the backup resources on the external provider system.
 	 * @param backup the backup details
 	 * @param opts additional options used during the backup deletion process


### PR DESCRIPTION
## Summary
While reviewing MORPH-15309, noticed that `PluginBackupExecutionService.updateBackup()` (morpheus-ui) already calls `pluginBackupTypeProvider.updateBackup(backupModel, opts)`, but `BackupTypeProvider` never declared such a method — so the call was dead code that never reliably resolved.

## Changes
- `BackupTypeProvider`: added `updateBackup(Backup, Map)` to the interface.
- `AbstractBackupTypeProvider`: delegates to `getExecutionProvider().updateBackup(...)`, mirroring `createBackup`/`deleteBackup`.
- `AbstractMorpheusBackupTypeProvider`: no-op success default, consistent with its other methods.
- `BackupExecutionProvider`: added `updateBackup(Backup, Map)` as a **default method** returning a no-op success. This method didn't exist before, so it was never called — a no-op default preserves that exact behavior for the ~10 existing plugins implementing this interface directly (Veeam, VMware, Commvault, etc.), while letting plugins opt in by overriding it to validate/apply changes on edit-save.

## Testing
- `./gradlew morpheus-plugin-api:compileJava` — builds clean.