### PR TITLE
feat(MORPH-16095): add SDS storage replication domain model SDK

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusStorageReplicationGroupService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusStorageReplicationGroupService.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright 2026 HPE Development Company, L.P.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+package com.morpheusdata.core;
+
+import com.morpheusdata.model.StorageReplicationGroup;
+import com.morpheusdata.model.projection.StorageReplicationGroupIdentityProjection;
+import io.reactivex.rxjava3.core.Observable;
+
+/**
+ * Context methods for dealing with {@link StorageReplicationGroup} in Morpheus.
+ * A replication group tracks the RPO, lag and failover state for a set of volumes
+ * being replicated to a {@link com.morpheusdata.model.StorageReplicationPartner}.
+ *
+ * @since 1.5.0
+ * @author HPE Storage Plugin Team
+ */
+public interface MorpheusStorageReplicationGroupService extends
+		MorpheusDataService<StorageReplicationGroup, StorageReplicationGroupIdentityProjection>,
+		MorpheusIdentityService<StorageReplicationGroupIdentityProjection> {
+
+	/**
+	 * List identity projections for all replication groups belonging to a storage server.
+	 *
+	 * @param storageServerId ID of the {@link com.morpheusdata.model.StorageServer}
+	 * @return Observable stream of identity projections
+	 */
+	Observable<StorageReplicationGroupIdentityProjection> listIdentityProjections(Long storageServerId);
+
+	/**
+	 * List replication groups whose {@code lagSeconds} exceeds {@code targetRpoSeconds}.
+	 * Used by the RPO breach detection scheduler.
+	 *
+	 * @param storageServerId ID of the {@link com.morpheusdata.model.StorageServer}
+	 * @return Observable stream of breaching groups
+	 */
+	Observable<StorageReplicationGroup> listRpoBreaches(Long storageServerId);
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusStorageReplicationPartnerService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusStorageReplicationPartnerService.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2026 HPE Development Company, L.P.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+package com.morpheusdata.core;
+
+import com.morpheusdata.model.StorageReplicationPartner;
+import com.morpheusdata.model.projection.StorageReplicationPartnerIdentityProjection;
+import io.reactivex.rxjava3.core.Observable;
+
+/**
+ * Context methods for dealing with {@link StorageReplicationPartner} in Morpheus.
+ * A replication partner represents a remote storage system that a local array
+ * replicates data to.
+ *
+ * @since 1.5.0
+ * @author HPE Storage Plugin Team
+ */
+public interface MorpheusStorageReplicationPartnerService extends
+		MorpheusDataService<StorageReplicationPartner, StorageReplicationPartnerIdentityProjection>,
+		MorpheusIdentityService<StorageReplicationPartnerIdentityProjection> {
+
+	/**
+	 * List identity projections for all replication partners belonging to a storage server.
+	 *
+	 * @param storageServerId ID of the local {@link com.morpheusdata.model.StorageServer}
+	 * @return Observable stream of identity projections
+	 */
+	Observable<StorageReplicationPartnerIdentityProjection> listIdentityProjections(Long storageServerId);
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusStorageService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusStorageService.java
@@ -22,50 +22,45 @@ import com.morpheusdata.model.NetworkServer;
 import com.morpheusdata.model.StorageServer;
 import com.morpheusdata.model.UpdateDefinition;
 import com.morpheusdata.response.ServiceResponse;
+import com.morpheusdata.core.MorpheusStorageReplicationPartnerService;
+import com.morpheusdata.core.MorpheusStorageReplicationGroupService;
 import io.reactivex.rxjava3.core.Single;
 
-/**
  * Provides a top level interface for interacting with Storage related services in Morpheus
  * @since 1.2.5
  * @author David Estes
  */
 public interface MorpheusStorageService {
-	/**
 	 * Returns the StorageVolume Service
 	 *
 	 * @return An instance of the StorageVolume Service
 	 */
 	MorpheusStorageVolumeService getVolume();
 
-	/**
 	 * Returns the StorageController Service
 	 *
 	 * @return An instance of the StorageController Service
 	 */
 	MorpheusStorageControllerService getController();
 
-	/**
 	 * Returns the StorageServer Service
 	 *
 	 * @return An instance of the StorageServer Service
 	 */
 	MorpheusStorageServerService getServer();
 
-	/**
 	 * Returns the StorageBucket Service
 	 *
 	 * @return An instance of the StorageBucket Service
 	 */
 	MorpheusStorageBucketService getBucket();
 
-	/**
 	 * Returns the StorageGroup Service
 	 *
 	 * @return An instance of the StorageGroup Service
 	 */
 	MorpheusStorageGroupService getGroup();
 
-	/**
 	 * Returns the StorageAggregate Service
 	 *
 	 * @return An instance of the StorageAggregate Service
@@ -73,49 +68,42 @@ public interface MorpheusStorageService {
 	 */
 	MorpheusStorageAggregateService getAggregate();
 
-	/**
 	 * Validates an update on a {@link StorageServer} before executing the update.
 	 * @deprecated use {@link MorpheusStorageServerService#validateUpdate(UpdateDefinition, StorageServer)}  instead
 	 */
 	@Deprecated
 	Single<ServiceResponse> validateUpdate(StorageServer storageServer, UpdateDefinition updateDefinition);
 
-	/**
 	 * Executes an update on a {@link StorageServer}.
 	 * @deprecated use {@link MorpheusStorageServerService#executeUpdate(UpdateDefinition, StorageServer)}  instead
 	 */
 	@Deprecated
 	Single<ServiceResponse> executeUpdate(StorageServer storageServer, UpdateDefinition updateDefinition);
 
-	/**
 	 * Post processes an update on a {@link StorageServer} after executing the update.
 	 * @deprecated use {@link MorpheusStorageServerService#postUpdate(UpdateDefinition, StorageServer)}  instead
 	 */
 	@Deprecated
 	Single<ServiceResponse> postUpdate(StorageServer storageServer, UpdateDefinition updateDefinition);
 
-	/**
 	 * Rolls back an update on a {@link StorageServer} if the update failed.
 	 * @deprecated use {@link MorpheusStorageServerService#rollbackUpdate(UpdateDefinition, StorageServer)}  instead
 	 */
 	@Deprecated
 	Single<ServiceResponse> rollbackUpdate(StorageServer storageServer, UpdateDefinition updateDefinition);
 
-	/**
 	 * Refresh the update status in a {@link StorageServer}.
 	 * @deprecated use {@link MorpheusStorageServerService#refreshUpdate(StorageServer)}  instead
 	 */
 	@Deprecated
 	Single<ServiceResponse> refreshUpdate(StorageServer storageServer);
 
-	/**
 	 * Run a configuration drift check on a {@link StorageServer}.
 	 * @deprecated use {@link MorpheusStorageServerService#runConfigurationDriftCheck(CheckLevel, StorageServer)}  instead
 	 */
 	@Deprecated
 	Single<ServiceResponse> runConfigurationDriftCheck(StorageServer storageServer, CheckLevel checkLevel);
 
-	/**
 	 * Get configuration drift details on a {@link StorageServer}.
 	 * @deprecated use {@link MorpheusStorageServerService#getConfigurationDriftDetails(StorageServer)}  instead
 	 */

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/StorageProviderReplication.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/StorageProviderReplication.java
@@ -1,0 +1,114 @@
+/*
+ *  Copyright 2026 HPE Development Company, L.P.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+package com.morpheusdata.core.providers;
+
+import com.morpheusdata.model.StorageReplicationGroup;
+import com.morpheusdata.model.StorageReplicationGroup.FailoverType;
+import com.morpheusdata.model.StorageReplicationPartner;
+import com.morpheusdata.model.StorageServer;
+import com.morpheusdata.response.ServiceResponse;
+
+import java.util.Map;
+
+/**
+ * Optional facet for {@link StorageProvider} implementations whose arrays support
+ * array-to-array replication. Paired with {@link StorageProvider} in the same way as
+ * {@link StorageProviderVolumes}.
+ *
+ * <p>A provider that does not implement this facet contributes nothing to the
+ * Replication tab. If no registered storage server implements it, the tab does not
+ * appear in the UI.
+ *
+ * @since 1.5.0
+ * @author HPE Storage Plugin Team
+ * @see StorageProvider
+ */
+public interface StorageProviderReplication {
+
+	/**
+	 * Create a replication relationship between two storage systems.
+	 *
+	 * @param storageServer the local {@link StorageServer}
+	 * @param group         the group to create, including partner and policy
+	 * @param opts          provider-specific options
+	 * @return ServiceResponse containing the persisted group on success
+	 */
+	ServiceResponse<StorageReplicationGroup> createReplicationGroup(
+			StorageServer storageServer, StorageReplicationGroup group, Map opts);
+
+	/**
+	 * Update the policy (mode, interval, RPO target) of an existing replication group.
+	 * The partner and volume group are fixed for the life of the relationship.
+	 *
+	 * @param storageServer the local {@link StorageServer}
+	 * @param group         the group with updated fields
+	 * @param opts          provider-specific options
+	 * @return ServiceResponse containing the updated group on success
+	 */
+	ServiceResponse<StorageReplicationGroup> updateReplicationGroup(
+			StorageServer storageServer, StorageReplicationGroup group, Map opts);
+
+	/**
+	 * Delete a replication relationship. The caller decides what happens to the
+	 * remote copy via {@code opts.deleteRemoteCopy}.
+	 *
+	 * @param storageServer the local {@link StorageServer}
+	 * @param group         the group to delete
+	 * @param opts          provider-specific options
+	 * @return ServiceResponse indicating success or failure
+	 */
+	ServiceResponse<StorageReplicationGroup> deleteReplicationGroup(
+			StorageServer storageServer, StorageReplicationGroup group, Map opts);
+
+	/**
+	 * Trigger a planned or unplanned failover. Planned flushes outstanding writes
+	 * before reversing roles; unplanned promotes the secondary while the primary
+	 * may be unreachable and may result in data loss.
+	 *
+	 * @param storageServer the local {@link StorageServer}
+	 * @param group         the group to fail over
+	 * @param type          {@link FailoverType#planned} or {@link FailoverType#unplanned}
+	 * @param opts          provider-specific options
+	 * @return ServiceResponse containing the updated group on success
+	 */
+	ServiceResponse<StorageReplicationGroup> failoverReplicationGroup(
+			StorageServer storageServer, StorageReplicationGroup group, FailoverType type, Map opts);
+
+	/**
+	 * Fail back to the original primary. Resyncs the recovered array, then reverses
+	 * roles. Never automatic — the operator must invoke this explicitly.
+	 *
+	 * @param storageServer the local {@link StorageServer}
+	 * @param group         the group to fail back
+	 * @param opts          provider-specific options
+	 * @return ServiceResponse containing the updated group on success
+	 */
+	ServiceResponse<StorageReplicationGroup> failbackReplicationGroup(
+			StorageServer storageServer, StorageReplicationGroup group, Map opts);
+
+	/**
+	 * Pause an active replication relationship without deleting it.
+	 *
+	 * @param storageServer the local {@link StorageServer}
+	 * @param group         the group to pause
+	 * @param opts          provider-specific options
+	 * @return ServiceResponse containing the updated group on success
+	 */
+	ServiceResponse<StorageReplicationGroup> pauseReplication(
+			StorageServer storageServer, StorageReplicationGroup group, Map opts);
+
+	/**
+	 * Resume a paused replication relationship.
+	 *
+	 * @param storageServer the local {@link StorageServer}
+	 * @param group         the group to resume
+	 * @param opts          provider-specific options
+	 * @return ServiceResponse containing the updated group on success
+	 */
+	ServiceResponse<StorageReplicationGroup> resumeReplication(
+			StorageServer storageServer, StorageReplicationGroup group, Map opts);
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/StorageReplicationGroup.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/StorageReplicationGroup.java
@@ -1,0 +1,120 @@
+/*
+ *  Copyright 2026 HPE Development Company, L.P.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.morpheusdata.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.morpheusdata.model.serializers.ModelAsIdOnlySerializer;
+import java.util.Date;
+
+/**
+ * Represents a set of volumes replicated together to a {@link StorageReplicationPartner},
+ * preserving write-order consistency across the set. Tracks RPO, lag and failover state
+ * so operators can assess data-protection posture at a glance.
+ *
+ * @since 1.5.0
+ * @author HPE Storage Plugin Team
+ */
+public class StorageReplicationGroup extends MorpheusModel {
+
+	public enum Mode         { periodic, synchronous }
+	public enum Role         { primary, secondary }
+	public enum FailoverState { none, failingOver, failedOver, failingBack }
+	public enum FailoverType { planned, unplanned }
+
+	@JsonSerialize(using = ModelAsIdOnlySerializer.class)
+	protected StorageServer storageServer;
+	@JsonSerialize(using = ModelAsIdOnlySerializer.class)
+	protected StorageReplicationPartner partner;
+
+	protected String name;
+	protected String code;
+	protected String externalId;
+	protected Mode mode = Mode.periodic;
+	protected Long intervalSeconds;
+	protected Role role = Role.primary;
+	/** syncing | in-sync | stopped | failed */
+	protected String status;
+	protected String statusMessage;
+	protected FailoverState failoverState = FailoverState.none;
+	protected FailoverType lastFailoverType;
+	protected Date lastFailoverDate;
+	/** Actual recovery-point lag in seconds. */
+	protected Long lagSeconds;
+	/** Target RPO in seconds; alert fires when lagSeconds exceeds this. */
+	protected Long targetRpoSeconds;
+	protected Date lastSyncDate;
+	protected String config;
+
+	public StorageServer getStorageServer() { return storageServer; }
+	public void setStorageServer(StorageServer storageServer) {
+		this.storageServer = storageServer; markDirty("storageServer", storageServer);
+	}
+
+	public StorageReplicationPartner getPartner() { return partner; }
+	public void setPartner(StorageReplicationPartner partner) {
+		this.partner = partner; markDirty("partner", partner);
+	}
+
+	public String getName() { return name; }
+	public void setName(String name) { this.name = name; markDirty("name", name); }
+
+	public String getCode() { return code; }
+	public void setCode(String code) { this.code = code; markDirty("code", code); }
+
+	public String getExternalId() { return externalId; }
+	public void setExternalId(String externalId) { this.externalId = externalId; markDirty("externalId", externalId); }
+
+	public Mode getMode() { return mode; }
+	public void setMode(Mode mode) { this.mode = mode; markDirty("mode", mode); }
+
+	public Long getIntervalSeconds() { return intervalSeconds; }
+	public void setIntervalSeconds(Long intervalSeconds) { this.intervalSeconds = intervalSeconds; markDirty("intervalSeconds", intervalSeconds); }
+
+	public Role getRole() { return role; }
+	public void setRole(Role role) { this.role = role; markDirty("role", role); }
+
+	public String getStatus() { return status; }
+	public void setStatus(String status) { this.status = status; markDirty("status", status); }
+
+	public String getStatusMessage() { return statusMessage; }
+	public void setStatusMessage(String statusMessage) { this.statusMessage = statusMessage; markDirty("statusMessage", statusMessage); }
+
+	public FailoverState getFailoverState() { return failoverState; }
+	public void setFailoverState(FailoverState failoverState) { this.failoverState = failoverState; markDirty("failoverState", failoverState); }
+
+	public FailoverType getLastFailoverType() { return lastFailoverType; }
+	public void setLastFailoverType(FailoverType lastFailoverType) { this.lastFailoverType = lastFailoverType; markDirty("lastFailoverType", lastFailoverType); }
+
+	public Date getLastFailoverDate() { return lastFailoverDate; }
+	public void setLastFailoverDate(Date lastFailoverDate) { this.lastFailoverDate = lastFailoverDate; markDirty("lastFailoverDate", lastFailoverDate); }
+
+	public Long getLagSeconds() { return lagSeconds; }
+	public void setLagSeconds(Long lagSeconds) { this.lagSeconds = lagSeconds; markDirty("lagSeconds", lagSeconds); }
+
+	public Long getTargetRpoSeconds() { return targetRpoSeconds; }
+	public void setTargetRpoSeconds(Long targetRpoSeconds) { this.targetRpoSeconds = targetRpoSeconds; markDirty("targetRpoSeconds", targetRpoSeconds); }
+
+	public Date getLastSyncDate() { return lastSyncDate; }
+	public void setLastSyncDate(Date lastSyncDate) { this.lastSyncDate = lastSyncDate; markDirty("lastSyncDate", lastSyncDate); }
+
+	public String getConfig() { return config; }
+	public void setConfig(String config) { this.config = config; markDirty("config", config); }
+
+	/** Returns true when actual lag exceeds the configured RPO target. */
+	public boolean isRpoBreach() {
+		return lagSeconds != null && targetRpoSeconds != null && lagSeconds > targetRpoSeconds;
+	}
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/StorageReplicationPartner.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/StorageReplicationPartner.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright 2026 HPE Development Company, L.P.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.morpheusdata.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.morpheusdata.model.serializers.ModelAsIdOnlySerializer;
+
+/**
+ * Represents a replication partner — a remote storage system that a local
+ * {@link StorageServer} replicates data to. One partner pairing can serve
+ * many {@link StorageReplicationGroup}s.
+ *
+ * @since 1.5.0
+ * @author HPE Storage Plugin Team
+ */
+public class StorageReplicationPartner extends MorpheusModel {
+
+	@JsonSerialize(using = ModelAsIdOnlySerializer.class)
+	protected StorageServer storageServer;
+
+	protected String name;
+	protected String code;
+	protected String externalId;
+	protected String partnerName;
+	protected String partnerExternalId;
+	/** RC network endpoint address of the partner array. */
+	protected String partnerAddress;
+	/** Set when both sides are Morpheus-managed; null for unmanaged remote arrays. */
+	@JsonSerialize(using = ModelAsIdOnlySerializer.class)
+	protected StorageServer partnerStorageServer;
+	/** connected | disconnected | degraded */
+	protected String status;
+	protected String statusMessage;
+	/** Transport type — ip (R1). */
+	protected String transportType;
+	protected String config;
+
+	public StorageServer getStorageServer() { return storageServer; }
+	public void setStorageServer(StorageServer storageServer) {
+		this.storageServer = storageServer;
+		markDirty("storageServer", storageServer);
+	}
+
+	public String getName() { return name; }
+	public void setName(String name) { this.name = name; markDirty("name", name); }
+
+	public String getCode() { return code; }
+	public void setCode(String code) { this.code = code; markDirty("code", code); }
+
+	public String getExternalId() { return externalId; }
+	public void setExternalId(String externalId) { this.externalId = externalId; markDirty("externalId", externalId); }
+
+	public String getPartnerName() { return partnerName; }
+	public void setPartnerName(String partnerName) { this.partnerName = partnerName; markDirty("partnerName", partnerName); }
+
+	public String getPartnerExternalId() { return partnerExternalId; }
+	public void setPartnerExternalId(String partnerExternalId) { this.partnerExternalId = partnerExternalId; markDirty("partnerExternalId", partnerExternalId); }
+
+	public String getPartnerAddress() { return partnerAddress; }
+	public void setPartnerAddress(String partnerAddress) { this.partnerAddress = partnerAddress; markDirty("partnerAddress", partnerAddress); }
+
+	public StorageServer getPartnerStorageServer() { return partnerStorageServer; }
+	public void setPartnerStorageServer(StorageServer partnerStorageServer) {
+		this.partnerStorageServer = partnerStorageServer;
+		markDirty("partnerStorageServer", partnerStorageServer);
+	}
+
+	public String getStatus() { return status; }
+	public void setStatus(String status) { this.status = status; markDirty("status", status); }
+
+	public String getStatusMessage() { return statusMessage; }
+	public void setStatusMessage(String statusMessage) { this.statusMessage = statusMessage; markDirty("statusMessage", statusMessage); }
+
+	public String getTransportType() { return transportType; }
+	public void setTransportType(String transportType) { this.transportType = transportType; markDirty("transportType", transportType); }
+
+	public String getConfig() { return config; }
+	public void setConfig(String config) { this.config = config; markDirty("config", config); }
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/projection/StorageReplicationGroupIdentityProjection.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/projection/StorageReplicationGroupIdentityProjection.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2026 HPE Development Company, L.P.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+package com.morpheusdata.model.projection;
+
+import com.morpheusdata.model.StorageReplicationGroup;
+
+/**
+ * Lightweight sync projection for {@link StorageReplicationGroup}.
+ * @since 1.5.0
+ */
+public class StorageReplicationGroupIdentityProjection extends MorpheusIdentityModel {
+
+	protected String name;
+	protected String externalId;
+
+	public StorageReplicationGroupIdentityProjection() {}
+	public StorageReplicationGroupIdentityProjection(Long id, String externalId) {
+		this.id = id;
+		this.externalId = externalId;
+	}
+
+	public String getName() { return name; }
+	public void setName(String name) { this.name = name; markDirty("name", name); }
+
+	public String getExternalId() { return externalId; }
+	public void setExternalId(String externalId) { this.externalId = externalId; markDirty("externalId", externalId); }
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/projection/StorageReplicationPartnerIdentityProjection.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/projection/StorageReplicationPartnerIdentityProjection.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2026 HPE Development Company, L.P.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+package com.morpheusdata.model.projection;
+
+import com.morpheusdata.model.StorageReplicationPartner;
+
+/**
+ * Lightweight sync projection for {@link StorageReplicationPartner}.
+ * @since 1.5.0
+ */
+public class StorageReplicationPartnerIdentityProjection extends MorpheusIdentityModel {
+
+	protected String name;
+	protected String externalId;
+
+	public StorageReplicationPartnerIdentityProjection() {}
+	public StorageReplicationPartnerIdentityProjection(Long id, String externalId) {
+		this.id = id;
+		this.externalId = externalId;
+	}
+
+	public String getName() { return name; }
+	public void setName(String name) { this.name = name; markDirty("name", name); }
+
+	public String getExternalId() { return externalId; }
+	public void setExternalId(String externalId) { this.externalId = externalId; markDirty("externalId", externalId); }
+}


### PR DESCRIPTION
- StorageReplicationPartner: SDK model (storageServer, partnerName, partnerAddress, transportType, status, config)
- StorageReplicationGroup: SDK model with mode/role/failover/RPO fields and isRpoBreach() helper
- StorageReplicationPartnerIdentityProjection
- StorageReplicationGroupIdentityProjection
- MorpheusStorageReplicationPartnerService: CRUD + listIdentityProjections
- MorpheusStorageReplicationGroupService: CRUD + listRpoBreaches
- StorageProviderReplication: optional plugin facet (7 methods)
- MorpheusStorageService: wired getReplicationPartner/getReplicationGroup